### PR TITLE
make header and side-bar ui parts non-selectable

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="override" style="display:none"></div>
 
     <div class="wrap">
-        <header class="header">
+        <header class="header unselectable">
             <span class="icon-menu" id="settings-trigger"></span>
 
             <div class="fl cps">
@@ -34,17 +34,17 @@
 
                         </li>
                         <!--
-                            <li id="tool-action" class="topAction"><a href="#" id="tool-action-href" class="topActionHref">
-                            <b>工具</b>
+                        <li id="tool-action" class="topAction"><a href="#" id="tool-action-href" class="topActionHref">
+                        <b>工具</b>
 
-                            </a>
-                            <ul class="tool-dropdown topDropdown">
-                                <li><span id="html-trigger">转换为 HTML</span></li>
-                                <li><span id="pdf-trigger">转换为 PDF</span></li>
-                                <li><span id="doc-trigger">转换为 DOC</span></li>
-                            </ul>
-                            </li>
-                            -->
+                        </a>
+                        <ul class="tool-dropdown topDropdown">
+                            <li><span id="html-trigger">转换为 HTML</span></li>
+                            <li><span id="pdf-trigger">转换为 PDF</span></li>
+                            <li><span id="doc-trigger">转换为 DOC</span></li>
+                        </ul>
+                        </li>
+                        -->
                         <input type="file" id="open_file" accept=".md,.markdown">
                         <input style="display:none" type="file" id="save_file" accept=".md,.markdown" nwsaveas>
                         <input style="display:none" type="file" id="save_html" accept=".html" nwsaveas>
@@ -64,7 +64,7 @@
             </div>
             <h1 class="current-file" data-save="false" data-sync-open="false">Miu</h1>
         </header>
-        <ul class="dropdown">
+        <ul class="dropdown unselectable">
             <li><span id="new-trigger">{{ 'NAV.file.option.new' | translate }}</span></li>
             <li><span id="open-trigger">{{ 'NAV.file.option.open' | translate }}</span></li>
             <li><span id="save-trigger">{{ 'NAV.file.option.save' | translate }}</span></li>
@@ -93,7 +93,7 @@
             </section>
         </div>
     </div><!--.wrap-->
-    <div class="settings">
+    <div class="settings unselectable">
         <div class="settings-top">
             <ul class="settings-tabs">
                 <div class="settings-sep"></div>

--- a/index.html
+++ b/index.html
@@ -1,159 +1,165 @@
-<!DOCTYPE html>
-<html >
-  <head>
-  <meta charset="utf-8">
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
     <title>Miu</title>
-    
-	<link rel="stylesheet" type="text/css" href="resource/css/main.css">
-  <link rel="stylesheet" type="text/css" href="resource/css/ghostdown.css">
-	<link rel="stylesheet" type="text/css" href="resource/fonts/icon/style.css">
-  <link rel="stylesheet" type="text/css" href="bower_components/hint.css/hint.min.css">
-	<link rel="stylesheet" type="text/css" href="bower_components/sweetalert/lib/sweet-alert.css">
-<link rel="stylesheet" type="text/css" href="node_modules/highlight.js/styles/github.css">	
 
-  </head>
-  <body ng-app="Miu">
-  <div class="sketch"></div>
-  <div class="override" style="display:none"></div>
-  
-  <div class="wrap">
-  <header class="header">
- <span class="icon-menu" id="settings-trigger"></span>
+    <link rel="stylesheet" type="text/css" href="resource/css/main.css">
+    <link rel="stylesheet" type="text/css" href="resource/css/ghostdown.css">
+    <link rel="stylesheet" type="text/css" href="resource/fonts/icon/style.css">
+    <link rel="stylesheet" type="text/css" href="bower_components/hint.css/hint.min.css">
+    <link rel="stylesheet" type="text/css" href="bower_components/sweetalert/lib/sweet-alert.css">
+    <link rel="stylesheet" type="text/css" href="node_modules/highlight.js/styles/github.css">
 
-  <div class="fl cps">
-				<a href="javascript:;" data-hint="Hide to tray" onclick="closeWindow()" class="osx-window-btn red hint--bottom hint--rounded"></a>
+</head>
+<body ng-app="Miu">
+    <div class="sketch"></div>
+    <div class="override" style="display:none"></div>
+
+    <div class="wrap">
+        <header class="header">
+            <span class="icon-menu" id="settings-trigger"></span>
+
+            <div class="fl cps">
+                <a href="javascript:;" data-hint="Hide to tray" onclick="closeWindow()" class="osx-window-btn red hint--bottom hint--rounded"></a>
                 <a href="javascript:;" data-hint="Minimize" onclick="miniWindow()" class="osx-window-btn yellow hint--bottom hint--rounded"></a>
                 <a href="javascript:;" data-hint="Maximize" onclick="maxWindow()" class="osx-window-btn green hint--bottom hint--rounded"></a>
                 <div class="control">
-                	<ul style="margin-left:20px" class="topControl">
-                		<li id="file-action" class="topAction"><a href="#" id="file-action-href" class="topActionHref">
-                		<b>{{ 'NAV.file.title' | translate }}</b>
-                		
-                		</a>
-                		
-                		</li>
-                    <!--
-                		<li id="tool-action" class="topAction"><a href="#" id="tool-action-href" class="topActionHref">
-                		<b>工具</b>
-                		
-                		</a>
-                		<ul class="tool-dropdown topDropdown">
-                			<li><span id="html-trigger">转换为 HTML</span></li>
-                			<li><span id="pdf-trigger">转换为 PDF</span></li>
-                			<li><span id="doc-trigger">转换为 DOC</span></li>
-                		</ul>
-                		</li>
-                		-->
-                		<input type="file" id="open_file" accept=".md,.markdown">
-                		<input style="display:none" type="file" id="save_file" accept=".md,.markdown" nwsaveas>
-                		<input style="display:none" type="file" id="save_html" accept=".html" nwsaveas>
-                		<input style="display:none" type="file" id="save_pdf" nwsaveas accept=".pdf">
-                		<input style="display:none" type="file" id="save_doc" accept=".doc" nwsaveas>
-                		<input style="display:none" type="file" id="savenew_file" accept=".md" nwsaveas>
-                		<li>
-                			<a href="javascript:;" id="about-trigger">{{ 'NAV.about' | translate }}</a>
-                		</li>
-                	</ul>
-                </div>
-  		</div>
-  		<!--<a href="javascript:;" onclick="fullScreen()" class="full">无扰</a>-->
-  	<div class="fr opts">
-  		<span class="entry-word-count fl">0 Words</span>
-  		<a href="javascript:;" class="hint--left hint--rounded" onclick="fullScreen()" data-hint="Fullscreen"><span class="icon-fullscreen expand"></span></a>
-  	</div>
- <h1 class="current-file" data-save="false" data-sync-open="false">Miu</h1>
-  </header>
-  <ul class="dropdown">
-                      <li><span id="new-trigger">{{ 'NAV.file.option.new' | translate }}</span></li>
-                      <li><span id="open-trigger">{{ 'NAV.file.option.open' | translate }}</span></li>
-                      <li><span id="save-trigger">{{ 'NAV.file.option.save' | translate }}</span></li>
-                      <li><span id="savenew-trigger">{{ 'NAV.file.option.saveas' | translate }}</span></li>
-                      <li><span id="html-trigger">{{ 'NAV.file.option.html' | translate }}</span></li>
-                      <li><span id="github-trigger">Github Gist</span></li>
+                    <ul style="margin-left:20px" class="topControl">
+                        <li id="file-action" class="topAction">
+                            <a href="#" id="file-action-href" class="topActionHref">
+                                <b>{{ 'NAV.file.title' | translate }}</b>
+
+                            </a>
+
+                        </li>
+                        <!--
+                            <li id="tool-action" class="topAction"><a href="#" id="tool-action-href" class="topActionHref">
+                            <b>工具</b>
+
+                            </a>
+                            <ul class="tool-dropdown topDropdown">
+                                <li><span id="html-trigger">转换为 HTML</span></li>
+                                <li><span id="pdf-trigger">转换为 PDF</span></li>
+                                <li><span id="doc-trigger">转换为 DOC</span></li>
+                            </ul>
+                            </li>
+                            -->
+                        <input type="file" id="open_file" accept=".md,.markdown">
+                        <input style="display:none" type="file" id="save_file" accept=".md,.markdown" nwsaveas>
+                        <input style="display:none" type="file" id="save_html" accept=".html" nwsaveas>
+                        <input style="display:none" type="file" id="save_pdf" nwsaveas accept=".pdf">
+                        <input style="display:none" type="file" id="save_doc" accept=".doc" nwsaveas>
+                        <input style="display:none" type="file" id="savenew_file" accept=".md" nwsaveas>
+                        <li>
+                            <a href="javascript:;" id="about-trigger">{{ 'NAV.about' | translate }}</a>
+                        </li>
                     </ul>
-    <div class="features">
-  <section class="editor">
-			<div class="outer">
-				<div class="editorwrap">
+                </div>
+            </div>
+            <!--<a href="javascript:;" onclick="fullScreen()" class="full">无扰</a>-->
+            <div class="fr opts">
+                <span class="entry-word-count fl">0 Words</span>
+                <a href="javascript:;" class="hint--left hint--rounded" onclick="fullScreen()" data-hint="Fullscreen"><span class="icon-fullscreen expand"></span></a>
+            </div>
+            <h1 class="current-file" data-save="false" data-sync-open="false">Miu</h1>
+        </header>
+        <ul class="dropdown">
+            <li><span id="new-trigger">{{ 'NAV.file.option.new' | translate }}</span></li>
+            <li><span id="open-trigger">{{ 'NAV.file.option.open' | translate }}</span></li>
+            <li><span id="save-trigger">{{ 'NAV.file.option.save' | translate }}</span></li>
+            <li><span id="savenew-trigger">{{ 'NAV.file.option.saveas' | translate }}</span></li>
+            <li><span id="html-trigger">{{ 'NAV.file.option.html' | translate }}</span></li>
+            <li><span id="github-trigger">Github Gist</span></li>
+        </ul>
+        <div class="features">
+            <section class="editor">
+                <div class="outer">
+                    <div class="editorwrap">
 
-					<section class="entry-markdown">
-						<section class="entry-markdown-content">
-<textarea id="original-file">**123**</textarea>
-						</section>
-					</section>
-					<section class="entry-preview active">
-						
-						<section class="entry-preview-content">
-							<div class="rendered-markdown"></div>
-						</section>
-					</section>
-				</div>
-			</div>
-		</section>
-		</div>
-</div><!--.wrap-->
+                        <section class="entry-markdown">
+                            <section class="entry-markdown-content">
+                                <textarea id="original-file">**123**</textarea>
+                            </section>
+                        </section>
+                        <section class="entry-preview active">
+
+                            <section class="entry-preview-content">
+                                <div class="rendered-markdown"></div>
+                            </section>
+                        </section>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div><!--.wrap-->
     <div class="settings">
-    <div class="settings-top">
-      <ul class="settings-tabs">
-      <div class="settings-sep"></div>
-        <li class="settings-tab"><a href="#" class="tabbed"><span class="icon-setting"></span> 
-        {{ 'SIDEBAR.setting' | translate }}</a></li>
+        <div class="settings-top">
+            <ul class="settings-tabs">
+                <div class="settings-sep"></div>
+                <li class="settings-tab">
+                    <a href="#" class="tabbed">
+                        <span class="icon-setting"></span>
+                        {{ 'SIDEBAR.setting' | translate }}
+                    </a>
+                </li>
 
-        <li class="settings-tab"><a href="#" id="cloud-trigger"><span class="icon-cloud"></span> {{ 'SIDEBAR.cloud.title' | translate }}</a></li>
-      </ul>
+                <li class="settings-tab"><a href="#" id="cloud-trigger"><span class="icon-cloud"></span> {{ 'SIDEBAR.cloud.title' | translate }}</a></li>
+            </ul>
+        </div>
+        <div class="settings-body">
+            <div class="notie gone"></div>
+            <label class="ios7-switch line-sample" id="colorful-label">
+                {{ 'SIDEBAR.colorful' | translate }}
+                <input type="checkbox" id="colorful-check">
+                <span></span>
+            </label>
+            <label class="ios7-switch line-sample" id="css-label" data-open="false">
+                {{ 'SIDEBAR.customcss' | translate }}
+
+                <i class="icon-chevron-right fr"></i>
+
+            </label>
+            <div class="css-label-cont gone">
+                <div id="css-input-trigger" class="sub-setting left2right">
+                    {{ 'SIDEBAR.preview.title' | translate }}  <b></b>
+                    <div>{{ 'SIDEBAR.preview.content' | translate }}</div>
+                </div>
+
+            </div>
+            <label class="ios7-switch line-sample" data-open="false">
+
+                <a href="#" id="auth_url"><div>{{ 'SIDEBAR.github' | translate }}</div></a>
+
+            </label>
+            <div class="github-label-cont gone">
+                <div class="sub-setting">
+                    <input type="text" id="github-token" placeholder="access_token (Ctrl + C)"> <button id="update-github">{{ 'GLOBAL.save' | translate }}</button>
+                </div>
+
+            </div>
+            <label class="ios7-switch line-sample" data-open="false" ng-controller="langCtrl" style="padding:0">
+
+                <a href="#" class="country" ng-click="changeLanguage('cn')"><img width="25" align="absmiddle" src="resource/img/flag/China.png"> 中文</a>
+                <a href="#" class="country" ng-click="changeLanguage('en')"><img width="25" align="absmiddle" src="resource/img/flag/USA.png"> English</a>
+                <a href="#" class="country" ng-click="changeLanguage('jp')"><img width="25" align="absmiddle" src="resource/img/flag/Japan.png"> 日本语</a>
+            </label>
+        </div>
     </div>
-      <div class="settings-body">
-      <div class="notie gone"></div>
-        <label class="ios7-switch line-sample" id="colorful-label">
-        {{ 'SIDEBAR.colorful' | translate }}
-        <input type="checkbox" id="colorful-check">
-        <span></span>
-       </label>
-        <label class="ios7-switch line-sample" id="css-label" data-open="false">
-        {{ 'SIDEBAR.customcss' | translate }}
 
-        <i class="icon-chevron-right fr"></i>
-        
-       </label>
-      <div class="css-label-cont gone">
-        <div id="css-input-trigger" class="sub-setting left2right">{{ 'SIDEBAR.preview.title' | translate }}  <b></b>
-       <div>{{ 'SIDEBAR.preview.content' | translate }}</div>
-        </div>
-          
-        </div>
-        <label class="ios7-switch line-sample" data-open="false">
-        
-        <a href="#" id="auth_url"><div>{{ 'SIDEBAR.github' | translate }}</div></a>
-        
-       </label>
-       <div class="github-label-cont gone">
-       <div class="sub-setting">
-         <input type="text" id="github-token" placeholder="access_token (Ctrl + C)"> <button id="update-github">{{ 'GLOBAL.save' | translate }}</button>
-        </div>
-        
-       </div>
-       <label class="ios7-switch line-sample" data-open="false" ng-controller="langCtrl" style="padding:0">
-        
-        <a href="#" class="country" ng-click="changeLanguage('cn')"><img width="25" align="absmiddle" src="resource/img/flag/China.png"> 中文</a>
-        <a href="#" class="country" ng-click="changeLanguage('en')"><img width="25" align="absmiddle" src="resource/img/flag/USA.png"> English</a>
-        <a href="#" class="country" ng-click="changeLanguage('jp')"><img width="25" align="absmiddle" src="resource/img/flag/Japan.png"> 日本语</a>
-       </label>
-      </div>
-    </div>
+    <script type="text/javascript" src="resource/js/jquery-2.0.3.min.js"></script>
+    <script src="resource/js/jquery-ui.js"></script>
+    <script type="text/javascript" src="bower_components/angular/angular.min.js"></script>
+    <script type="text/javascript" src="bower_components/angular-translate/angular-translate.min.js"></script>
 
-		<script type="text/javascript" src="resource/js/jquery-2.0.3.min.js"></script>
-    	 <script src="resource/js/jquery-ui.js"></script>
-       <script type="text/javascript" src="bower_components/angular/angular.min.js"></script>
-       <script type="text/javascript" src="bower_components/angular-translate/angular-translate.min.js"></script>
-      
     <script type="text/javascript" src="resource/js/ghostdown.js"></script>
-	
-	<script type="text/javascript" src="resource/js/jquery.ghostdown.js"></script>
-  <script type="text/javascript" src="bower_components/simpleStorage/simpleStorage.js"></script>
-   
-	<script type="text/javascript" src="resource/js/app.js"></script>
-  <script type="text/javascript" src="resource/js/i18n.js"></script>
-<script type="text/javascript" src="bower_components/sweetalert/lib/sweet-alert.js"></script>
-<input type="file" class="gone" id="css-input" accept=".css">
-  </body>
+
+    <script type="text/javascript" src="resource/js/jquery.ghostdown.js"></script>
+    <script type="text/javascript" src="bower_components/simpleStorage/simpleStorage.js"></script>
+
+    <script type="text/javascript" src="resource/js/app.js"></script>
+    <script type="text/javascript" src="resource/js/i18n.js"></script>
+    <script type="text/javascript" src="bower_components/sweetalert/lib/sweet-alert.js"></script>
+    <input type="file" class="gone" id="css-input" accept=".css">
+</body>
 </html>

--- a/resource/css/ghostdown.css
+++ b/resource/css/ghostdown.css
@@ -1,601 +1,724 @@
-body {	
-	font-size: 16px;
-	overflow: hidden;
+body {
+    font-size: 16px;
+    overflow: hidden;
 }
+
 .CodeMirror {
-	font-family: monospace;
-	height: 300px
+    font-family: monospace;
+    height: 300px;
 }
+
 .CodeMirror-scroll {
-	overflow: auto
+    overflow: auto;
 }
+
 .CodeMirror-lines {
-	padding: 4px 0
+    padding: 4px 0;
 }
+
 .CodeMirror pre {
-	padding: 0 4px
+    padding: 0 4px;
 }
+
 .CodeMirror-scrollbar-filler {
-	background-color: white
+    background-color: white;
 }
+
 .CodeMirror-gutters {
-	border-right: 1px solid #ddd;
-	background-color: #f7f7f7
+    border-right: 1px solid #ddd;
+    background-color: #f7f7f7;
 }
+
 .CodeMirror-linenumber {
-	padding: 0 3px 0 5px;
-	min-width: 20px;
-	text-align: right;
-	color: #999
+    padding: 0 3px 0 5px;
+    min-width: 20px;
+    text-align: right;
+    color: #999;
 }
+
 .CodeMirror div.CodeMirror-cursor {
-	border-left: 1px solid black
+    border-left: 1px solid black;
 }
+
 .CodeMirror div.CodeMirror-secondarycursor {
-	border-left: 1px solid silver
+    border-left: 1px solid silver;
 }
+
 .CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor {
-	width: auto;
-	border: 0;
-	background: transparent;
-	background: rgba(0,200,0,0.4);
-filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#6600c800, endColorstr=#4c00c800)
+    width: auto;
+    border: 0;
+    background: transparent;
+    background: rgba(0,200,0,0.4);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#6600c800, endColorstr=#4c00c800);
 }
-.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor:not(#nonsense_id) {
-filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)
-}
+
+    .CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor:not(#nonsense_id) {
+        filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+    }
+
 .cm-s-default .cm-keyword {
-	color: #708
+    color: #708;
 }
+
 .cm-s-default .cm-atom {
-	color: #219
+    color: #219;
 }
+
 .cm-s-default .cm-number {
-	color: #164
+    color: #164;
 }
+
 .cm-s-default .cm-def {
-	color: #00f
+    color: #00f;
 }
+
 .cm-s-default .cm-variable {
-	color: black
+    color: black;
 }
+
 .cm-s-default .cm-variable-2 {
-	color: #05a
+    color: #05a;
 }
+
 .cm-s-default .cm-variable-3 {
-	color: #085
+    color: #085;
 }
+
 .cm-s-default .cm-property {
-	color: black
+    color: black;
 }
+
 .cm-s-default .cm-operator {
-	color: black
+    color: black;
 }
+
 .cm-s-default .cm-comment {
-	color: #a50
+    color: #a50;
 }
+
 .cm-s-default .cm-string {
-	color: #a11;
-	font-size: 14px;
+    color: #a11;
+    font-size: 14px;
 }
+
 .cm-s-default .cm-string-2 {
-	color: #f50;
+    color: #f50;
 }
+
 .cm-s-default .cm-meta {
-	color: #555
+    color: #555;
 }
+
 .cm-s-default .cm-error {
-	color: #f00
+    color: #f00;
 }
+
 .cm-s-default .cm-qualifier {
-	color: #555
+    color: #555;
 }
+
 .cm-s-default .cm-builtin {
-	color: #30a
+    color: #30a;
 }
+
 .cm-s-default .cm-bracket {
-	color: #997
+    color: #997;
 }
+
 .cm-s-default .cm-tag {
-	color: #4e279a
+    color: #4e279a;
 }
+
 .cm-s-default .cm-attribute {
-	color: #00c
+    color: #00c;
 }
+
 .cm-s-default .cm-header {
-	color: blue
+    color: blue;
 }
+
 .cm-s-default .cm-quote {
-	color: #93a1a1
+    color: #93a1a1;
 }
+
 .cm-s-default .cm-hr {
-	color: #999
+    color: #999;
 }
+
 .cm-s-default .cm-link {
-	color: #00c
+    color: #00c;
 }
+
 .cm-negative {
-	color: #d44
+    color: #d44;
 }
+
 .cm-positive {
-	color: #292
+    color: #292;
 }
-.features .editor .cm-del{
-	color: #999;
+
+.features .editor .cm-del {
+    color: #999;
 }
+
 .cm-header, .cm-strong {
-	font-weight: bold;
-	color: #dc322f;
+    font-weight: bold;
+    color: #dc322f;
 }
-.features .editor .cm-header2{
-	font-size: 20px;
+
+.features .editor .cm-header2 {
+    font-size: 20px;
 }
-.features .editor .cm-header3{
-	font-size: 18px;
+
+.features .editor .cm-header3 {
+    font-size: 18px;
 }
-.features .editor .cm-header4{
-	font-size: 16px;
+
+.features .editor .cm-header4 {
+    font-size: 16px;
 }
+
 .cm-em {
-	font-style: italic
+    font-style: italic;
 }
+
 .cm-emstrong {
-	font-style: italic;
-	font-weight: bold
+    font-style: italic;
+    font-weight: bold;
 }
+
 .cm-link {
-	text-decoration: underline
+    text-decoration: underline;
 }
+
 .cm-invalidchar {
-	color: #f00
+    color: #f00;
 }
+
 div.CodeMirror span.CodeMirror-matchingbracket {
-	color: #0f0
+    color: #0f0;
 }
+
 div.CodeMirror span.CodeMirror-nonmatchingbracket {
-	color: #f22
+    color: #f22;
 }
+
 .CodeMirror {
-	line-height: 1;
-	position: relative;
-	overflow: hidden
+    line-height: 1;
+    position: relative;
+    overflow: hidden;
 }
+
 .CodeMirror-scroll {
-	margin-bottom: 0;
-	margin-right: -30px;
-	padding-bottom: 30px;
-	padding-right: 30px;
-	height: 100%;
-	outline: none;
-	position: relative
+    margin-bottom: 0;
+    margin-right: -30px;
+    padding-bottom: 30px;
+    padding-right: 30px;
+    height: 100%;
+    outline: none;
+    position: relative;
 }
+
 .CodeMirror-sizer {
-	position: relative
+    position: relative;
 }
+
 .CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler {
-	position: absolute;
-	z-index: 6;
-	display: none
+    position: absolute;
+    z-index: 6;
+    display: none;
 }
+
 .CodeMirror-vscrollbar {
-	right: 0;
-	top: 0;
-	overflow-x: hidden;
-	overflow-y: scroll
+    right: 0;
+    top: 0;
+    overflow-x: hidden;
+    overflow-y: scroll;
 }
+
 .CodeMirror-hscrollbar {
-	bottom: 0;
-	left: 0;
-	overflow-y: hidden;
-	overflow-x: scroll
+    bottom: 0;
+    left: 0;
+    overflow-y: hidden;
+    overflow-x: scroll;
 }
+
 .CodeMirror-scrollbar-filler {
-	right: 0;
-	bottom: 0;
-	z-index: 6
+    right: 0;
+    bottom: 0;
+    z-index: 6;
 }
+
 .CodeMirror-gutters {
-	position: absolute;
-	left: 0;
-	top: 0;
-	height: 100%;
-	padding-bottom: 30px;
-	z-index: 3
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    padding-bottom: 30px;
+    z-index: 3;
 }
+
 .CodeMirror-gutter {
-	height: 100%;
-	display: inline-block;
-*zoom:1;
-*display:inline
+    height: 100%;
+    display: inline-block;
+    *zoom: 1;
+    *display: inline;
 }
+
 .CodeMirror-gutter-elt {
-	position: absolute;
-	cursor: default;
-	z-index: 4
+    position: absolute;
+    cursor: default;
+    z-index: 4;
 }
+
 .CodeMirror-lines {
-	cursor: text
+    cursor: text;
 }
-.CodeMirror pre,pre code {
-	-moz-border-radius: 0;
-	-webkit-border-radius: 0;
-	-o-border-radius: 0;
-	border-radius: 0;
-	border-width: 0;
-	background: transparent;
-	font-family: inherit;
-	font-size: inherit;
-	margin: 0;
-	white-space: pre;
-	word-wrap: normal;
-	line-height: inherit;
-	color: inherit;
-	z-index: 2;
-	position: relative;
-	overflow: visible
+
+.CodeMirror pre, pre code {
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+    -o-border-radius: 0;
+    border-radius: 0;
+    border-width: 0;
+    background: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    margin: 0;
+    white-space: pre;
+    word-wrap: normal;
+    line-height: inherit;
+    color: inherit;
+    z-index: 2;
+    position: relative;
+    overflow: visible;
 }
-.CodeMirror-wrap pre,pre code {
-	word-wrap: break-word;
-	white-space: pre-wrap;
-	word-break: normal
+
+.CodeMirror-wrap pre, pre code {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    word-break: normal;
 }
+
 .CodeMirror-linebackground {
-	position: absolute;
-	left: 0;
-	right: 0;
-	top: 0;
-	bottom: 0;
-	z-index: 0
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
 }
+
 .CodeMirror-linewidget {
-	position: relative;
-	z-index: 2;
-	overflow: auto
+    position: relative;
+    z-index: 2;
+    overflow: auto;
 }
+
 .CodeMirror-widget {
-	display: inline-block
+    display: inline-block;
 }
+
 .CodeMirror-wrap .CodeMirror-scroll {
-	overflow-x: hidden
+    overflow-x: hidden;
 }
+
 .CodeMirror-measure {
-	position: absolute;
-	width: 100%;
-	height: 0px;
-	overflow: hidden;
-	visibility: hidden
+    position: absolute;
+    width: 100%;
+    height: 0px;
+    overflow: hidden;
+    visibility: hidden;
 }
-.CodeMirror-measure pre {
-	position: static
-}
+
+    .CodeMirror-measure pre {
+        position: static;
+    }
+
 .CodeMirror div.CodeMirror-cursor {
-	position: absolute;
-	visibility: hidden;
-	border-right: none;
-	width: 0
+    position: absolute;
+    visibility: hidden;
+    border-right: none;
+    width: 0;
 }
+
 .CodeMirror-focused div.CodeMirror-cursor {
-	visibility: visible
+    visibility: visible;
 }
+
 .CodeMirror-selected {
-	background: #d9d9d9
+    background: #d9d9d9;
 }
+
 .CodeMirror-focused .CodeMirror-selected {
-	background: #d7d4f0
+    background: #d7d4f0;
 }
+
 .cm-searching {
-	background: #ffa;
-	background: rgba(255,255,0,0.4)
+    background: #ffa;
+    background: rgba(255,255,0,0.4);
 }
+
 .CodeMirror span {
-*vertical-align:text-bottom
+    *vertical-align: text-bottom;
 }
+
 @media print {
-.CodeMirror div.CodeMirror-cursor {
-	visibility: hidden
-}
+    .CodeMirror div.CodeMirror-cursor {
+        visibility: hidden;
+    }
 }
 
 
 @media (max-width: 860px), (max-width: 860px) {
 
-.features .editor .outer {
-	padding: 0 40px
+    .features .editor .outer {
+        padding: 0 40px;
+    }
 }
-}
+
 @media (max-width: 800px), (max-width: 800px) {
-.features .editor .outer {
-	padding: 0 30px
-}
-}
-@media (max-width: 400px), (max-width: 400px) {
-.features .editor .outer {
-	padding: 0 15px
-}
-}
-.features .editor .editorwrap {
-	max-width: 100%;
-	padding: 0 10px;
-	margin: 0 auto;
-	position: relative;
-	height: 450px
-}
-@media (max-width: 860px), (max-width: 860px) {
-.features .editor .editorwrap {
-	height: 400px
-}
-}
-@media (max-width: 600px), (max-width: 600px) {
-.features .editor .editorwrap {
-	height: 480px
-}
-}
-@media (max-width: 400px), (max-width: 400px) {
-.features .editor .editorwrap {
-	height: 530px
-}
-}
-.features .editor .entry-markdown {
-	left: 0;
-	padding-left: 40px;
-	min-height: 90vmin;
-}
-.features .editor .entry-preview {
-	font-size: 16px;
-	right: 0;
-	box-shadow: #edece4 -1px 0 0;
-	min-height: 100vmin;
-}
-.entry-preview img{
-	max-width: 100%;
-}
-.features .editor .entry-markdown, .features .editor .entry-preview {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-	width: 50%;
-	position: absolute;
-	bottom: 0;
-	top: 0;
-	background: #fff
-}
-@media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-markdown, .features .editor .entry-preview {
-	bottom: 40px
-}
-}
-@media (max-width: 400px), (max-width: 400px) {
-.features .editor .entry-markdown, .features .editor .entry-preview {
-	box-shadow: none
-}
-}
-@media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-markdown, .features .editor .entry-preview {
-	top: 0;
-	left: 0;
-	right: 0;
-	width: 100%;
-	border: none;
-	z-index: 100;
-	box-shadow: #edece4 1px 0 0 inset, #edece4 -1px 0 0 inset, #edece4 0 -1px 0 inset
-}
-.features .editor .entry-markdown .markdown, .features .editor .entry-markdown .entry-preview-content, .features .editor .entry-preview .markdown, .features .editor .entry-preview .entry-preview-content {
-	height: 50px;
-	overflow: hidden
-}
-}
-@media (min-width: 860px) and (min-width: 860px), (min-width: 860px) and (min-width: 860px) {
-.features .editor .entry-markdown .floatingheader, .features .editor .entry-preview .floatingheader {
-	padding-left: 20px;
-	padding-right: 18px;
-	margin-right: 1px
-}
-}
-@media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-markdown .floatingheader, .features .editor .entry-preview .floatingheader {
-	cursor: pointer;
-	width: 50%;
-	border: none;
-	color: #fff;
-	background: #aaa9a2;
-	position: absolute;
-	top: -40px;
-	left: 0;
-	box-shadow: rgba(0,0,0,0.1) 0 -2px 3px inset;
-	padding: 10px 0;
-}
-.features .editor .entry-markdown .floatingheader a, .features .editor .entry-preview .floatingheader a {
-	color: #fff
-}
-}
-.features .editor .entry-markdown .floatingheader a, .features .editor .entry-preview .floatingheader a {
-	color: #aaa9a2
-}
-.features .editor .entry-markdown.active, .features .editor .entry-preview.active {
-	z-index: 200
-}
-.features .editor .entry-markdown.active .markdown, .features .editor .entry-markdown.active .entry-preview-content, .features .editor .entry-preview.active .markdown, .features .editor .entry-preview.active .entry-preview-content {
-	height: auto;
-	overflow: auto
-}
-@media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-markdown.active header, .features .editor .entry-preview.active header {
-	cursor: auto;
-	color: #aaa9a2;
-	background: #fff;
-	box-shadow: #edece4 0 1px 0 inset, #edece4 1px 0 0 inset, #edece4 -1px 0 0 inset
-}
-.features .editor .entry-markdown.active header a, .features .editor .entry-preview.active header a {
-	color: #aaa9a2
-}
-}
-@media (max-width: 400px), (max-width: 400px) {
-.features .editor .entry-markdown .markdown-help, .features .editor .entry-markdown .entry-word-count, .features .editor .entry-preview .markdown-help, .features .editor .entry-preview .entry-word-count {
-	display: none
-}
-}
-.features .editor .markdown-help {
-	float: right
-}
-.features .editor .markdown-help:before {
-	font-family: "Icons";
-	font-weight: normal;
-	font-style: normal;
-	vertical-align: -7%;
-	text-transform: none;
-	speak: none;
-	line-height: 1;
-	-webkit-font-smoothing: antialiased;
-	content: "\e01b";
-	color: #cfceca
-}
-.features .editor .markdown-help:hover {
-	text-decoration: none
-}
-.features .editor .markdown-help:hover:before {
-	font-family: "Icons";
-	font-weight: normal;
-	font-style: normal;
-	vertical-align: -7%;
-	text-transform: none;
-	speak: none;
-	line-height: 1;
-	-webkit-font-smoothing: antialiased;
-	content: "\e01b";
-	color: #aaa9a2
-}
-.features .editor .markdown-help:hover:hover {
-	text-decoration: none
-}
-.features .editor .entry-word-count {
-	float: right;
-	padding-right: 22px
-}
-@media (min-width: 860px) and (min-width: 860px), (min-width: 860px) and (min-width: 860px) {
-.features {
-	margin-top: 0px;
+    .features .editor .outer {
+        padding: 0 30px;
+    }
 }
 
-.features .editor .entry-markdown .floatingheader {
-	padding-left: 0;
-	left: -30px;
-	position: relative;
+@media (max-width: 400px), (max-width: 400px) {
+    .features .editor .outer {
+        padding: 0 15px;
+    }
 }
+
+.features .editor .editorwrap {
+    max-width: 100%;
+    padding: 0 10px;
+    margin: 0 auto;
+    position: relative;
+    height: 450px;
 }
+
+@media (max-width: 860px), (max-width: 860px) {
+    .features .editor .editorwrap {
+        height: 400px;
+    }
+}
+
+@media (max-width: 600px), (max-width: 600px) {
+    .features .editor .editorwrap {
+        height: 480px;
+    }
+}
+
+@media (max-width: 400px), (max-width: 400px) {
+    .features .editor .editorwrap {
+        height: 530px;
+    }
+}
+
+.features .editor .entry-markdown {
+    left: 0;
+    padding-left: 40px;
+    min-height: 90vmin;
+}
+
+.features .editor .entry-preview {
+    font-size: 16px;
+    right: 0;
+    box-shadow: #edece4 -1px 0 0;
+    min-height: 100vmin;
+}
+
+.entry-preview img {
+    max-width: 100%;
+}
+
+.features .editor .entry-markdown, .features .editor .entry-preview {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    width: 50%;
+    position: absolute;
+    bottom: 0;
+    top: 0;
+    background: #fff;
+}
+
+@media (max-width: 860px), (max-width: 860px) {
+    .features .editor .entry-markdown, .features .editor .entry-preview {
+        bottom: 40px;
+    }
+}
+
+@media (max-width: 400px), (max-width: 400px) {
+    .features .editor .entry-markdown, .features .editor .entry-preview {
+        box-shadow: none;
+    }
+}
+
+@media (max-width: 860px), (max-width: 860px) {
+    .features .editor .entry-markdown, .features .editor .entry-preview {
+        top: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        border: none;
+        z-index: 100;
+        box-shadow: #edece4 1px 0 0 inset, #edece4 -1px 0 0 inset, #edece4 0 -1px 0 inset;
+    }
+
+        .features .editor .entry-markdown .markdown, .features .editor .entry-markdown .entry-preview-content, .features .editor .entry-preview .markdown, .features .editor .entry-preview .entry-preview-content {
+            height: 50px;
+            overflow: hidden;
+        }
+}
+
+@media (min-width: 860px) and (min-width: 860px), (min-width: 860px) and (min-width: 860px) {
+    .features .editor .entry-markdown .floatingheader, .features .editor .entry-preview .floatingheader {
+        padding-left: 20px;
+        padding-right: 18px;
+        margin-right: 1px;
+    }
+}
+
+@media (max-width: 860px), (max-width: 860px) {
+    .features .editor .entry-markdown .floatingheader, .features .editor .entry-preview .floatingheader {
+        cursor: pointer;
+        width: 50%;
+        border: none;
+        color: #fff;
+        background: #aaa9a2;
+        position: absolute;
+        top: -40px;
+        left: 0;
+        box-shadow: rgba(0,0,0,0.1) 0 -2px 3px inset;
+        padding: 10px 0;
+    }
+
+        .features .editor .entry-markdown .floatingheader a, .features .editor .entry-preview .floatingheader a {
+            color: #fff;
+        }
+}
+
+.features .editor .entry-markdown .floatingheader a, .features .editor .entry-preview .floatingheader a {
+    color: #aaa9a2;
+}
+
+.features .editor .entry-markdown.active, .features .editor .entry-preview.active {
+    z-index: 200;
+}
+
+    .features .editor .entry-markdown.active .markdown, .features .editor .entry-markdown.active .entry-preview-content, .features .editor .entry-preview.active .markdown, .features .editor .entry-preview.active .entry-preview-content {
+        height: auto;
+        overflow: auto;
+    }
+
+@media (max-width: 860px), (max-width: 860px) {
+    .features .editor .entry-markdown.active header, .features .editor .entry-preview.active header {
+        cursor: auto;
+        color: #aaa9a2;
+        background: #fff;
+        box-shadow: #edece4 0 1px 0 inset, #edece4 1px 0 0 inset, #edece4 -1px 0 0 inset;
+    }
+
+        .features .editor .entry-markdown.active header a, .features .editor .entry-preview.active header a {
+            color: #aaa9a2;
+        }
+}
+
+@media (max-width: 400px), (max-width: 400px) {
+    .features .editor .entry-markdown .markdown-help, .features .editor .entry-markdown .entry-word-count, .features .editor .entry-preview .markdown-help, .features .editor .entry-preview .entry-word-count {
+        display: none;
+    }
+}
+
+.features .editor .markdown-help {
+    float: right;
+}
+
+    .features .editor .markdown-help:before {
+        font-family: "Icons";
+        font-weight: normal;
+        font-style: normal;
+        vertical-align: -7%;
+        text-transform: none;
+        speak: none;
+        line-height: 1;
+        -webkit-font-smoothing: antialiased;
+        content: "\e01b";
+        color: #cfceca;
+    }
+
+    .features .editor .markdown-help:hover {
+        text-decoration: none;
+    }
+
+        .features .editor .markdown-help:hover:before {
+            font-family: "Icons";
+            font-weight: normal;
+            font-style: normal;
+            vertical-align: -7%;
+            text-transform: none;
+            speak: none;
+            line-height: 1;
+            -webkit-font-smoothing: antialiased;
+            content: "\e01b";
+            color: #aaa9a2;
+        }
+
+        .features .editor .markdown-help:hover:hover {
+            text-decoration: none;
+        }
+
+.features .editor .entry-word-count {
+    float: right;
+    padding-right: 22px;
+}
+
+@media (min-width: 860px) and (min-width: 860px), (min-width: 860px) and (min-width: 860px) {
+    .features {
+        margin-top: 0px;
+    }
+
+        .features .editor .entry-markdown .floatingheader {
+            padding-left: 0;
+            left: -30px;
+            position: relative;
+        }
+}
+
 .features .editor .entry-markdown-content textarea {
-	border: 0;
-	width: 100%;
-	height: 100%;
-	max-width: 100%;
-	margin: 0;
-	padding: 0;
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0
+    border: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 }
-.features .editor .entry-markdown-content textarea:focus {
-	outline: 0
-}
+
+    .features .editor .entry-markdown-content textarea:focus {
+        outline: 0;
+    }
+
 .features .editor .CodeMirror {
-	height: auto;
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	padding-top: 20px;
-	font-family: 'Menlo',Helvetica, monospace, Serif;
-	font-size: 16px;
-	line-height: 1.3em;
-	color: #6c7379
+    height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding-top: 20px;
+    font-family: 'Menlo',Helvetica, monospace, Serif;
+    font-size: 16px;
+    line-height: 1.3em;
+    color: #6c7379;
 }
-.features .editor .CodeMirror .CodeMirror-focused, .features .editor .CodeMirror .CodeMirror-selected {
-	color: #242628;
-	background: #b3d5f3;
-	text-shadow: none
-}
-.features .editor .CodeMirror ::selection {
-	color: #242628;
-	background: #b3d5f3;
-	text-shadow: none
-}
+
+    .features .editor .CodeMirror .CodeMirror-focused, .features .editor .CodeMirror .CodeMirror-selected {
+        color: #242628;
+        background: #b3d5f3;
+        text-shadow: none;
+    }
+
+    .features .editor .CodeMirror ::selection {
+        color: #242628;
+        background: #b3d5f3;
+        text-shadow: none;
+    }
+
 .features .editor .CodeMirror-lines {
-	padding: 0 0 40px 0
+    padding: 0 0 40px 0;
 }
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .CodeMirror-lines {
-	padding: 5px 0 30px 0
+    .features .editor .CodeMirror-lines {
+        padding: 5px 0 30px 0;
+    }
 }
-}
+
 @media (max-width: 400px), (max-width: 400px) {
-.features .editor .CodeMirror-lines {
-	padding: 5px 0
+    .features .editor .CodeMirror-lines {
+        padding: 5px 0;
+    }
 }
-}
+
 .features .editor .CodeMirror pre {
-	padding: 0 20px
+    padding: 0 20px;
 }
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .CodeMirror pre {
-	padding: 0 30px
+    .features .editor .CodeMirror pre {
+        padding: 0 30px;
+    }
 }
-}
+
 @media (max-width: 400px), (max-width: 400px) {
-.features .editor .CodeMirror pre {
-	padding: 0 15px
+    .features .editor .CodeMirror pre {
+        padding: 0 15px;
+    }
 }
+
+.features .editor .cm-header, .cm-header2, .cm-header3, .cm-header4 {
+    color: #6c71c4;
+    font-weight: bold;
+    font-size: 24px;
+    line-height: 1.4em;
 }
-.features .editor .cm-header,.cm-header2,.cm-header3,.cm-header4 {
-		color: #6c71c4;
-	font-weight: bold;
-	font-size: 24px;
-	line-height: 1.4em
-}
+
 .features .editor .cm-string, .features .editor .cm-link, .features .editor .cm-comment, .features .editor .cm-quote {
-	color: #93a1a1
+    color: #93a1a1;
 }
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-preview .floatingheader {
-	right: 0;
-	left: auto;
-	border: none
+    .features .editor .entry-preview .floatingheader {
+        right: 0;
+        left: auto;
+        border: none;
+    }
 }
-}
+
 .features .editor .entry-preview-content {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	padding: 10px 40px 192px 30px;
-	overflow: auto;
-	font-size: 0.95em
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding: 10px 40px 192px 30px;
+    overflow: auto;
+    font-size: 0.95em;
 }
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .entry-preview-content {
-	padding: 30px
+    .features .editor .entry-preview-content {
+        padding: 30px;
+    }
 }
-}
+
 @media (max-width: 400px), (max-width: 400px) {
-.features .editor .entry-preview-content {
-	padding: 15px 15px 10px 15px
+    .features .editor .entry-preview-content {
+        padding: 15px 15px 10px 15px;
+    }
 }
-}
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .scrolling .floatingheader {
-	height: 39px;
-	box-shadow: none
+    .features .editor .scrolling .floatingheader {
+        height: 39px;
+        box-shadow: none;
+    }
 }
-}
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .scrolling .floatingheader::before, .features .editor .scrolling .floatingheader::after {
-	display: none
+    .features .editor .scrolling .floatingheader::before, .features .editor .scrolling .floatingheader::after {
+        display: none;
+    }
 }
-}
+
 @media (max-width: 860px), (max-width: 860px) {
-.features .editor .scrolling .CodeMirror-scroll, .features .editor .scrolling .entry-preview-content {
-	box-shadow: 0 3px 5px rgba(0,0,0,0.05) inset
-}
+    .features .editor .scrolling .CodeMirror-scroll, .features .editor .scrolling .entry-preview-content {
+        box-shadow: 0 3px 5px rgba(0,0,0,0.05) inset;
+    }
 }

--- a/resource/css/ghostdown.css
+++ b/resource/css/ghostdown.css
@@ -425,7 +425,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
     font-size: 16px;
     right: 0;
     box-shadow: #edece4 -1px 0 0;
-    min-height: 100vmin;
+    min-height: 90vmin;
 }
 
 .entry-preview img {

--- a/resource/css/main.css
+++ b/resource/css/main.css
@@ -10,6 +10,12 @@ body {
     margin: 0;
 }
 
+.unselectable {
+    -webkit-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+}
+
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;
 }

--- a/resource/css/main.css
+++ b/resource/css/main.css
@@ -1,18 +1,202 @@
-/*! normalize.css v3.0.1 | MIT License | git.io/normalize */html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}h1{font-size:2em;margin:.67em 0}mark{background:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}button{overflow:visible}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}input{line-height:normal}input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:.35em .625em .75em}legend{border:0;padding:0}textarea{overflow:auto}optgroup{font-weight:bold}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}
+/*! normalize.css v3.0.1 | MIT License | git.io/normalize */
+
+html {
+    font-family: sans-serif;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+}
+
+body {
+    margin: 0;
+}
+
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
+    display: block;
+}
+
+audio, canvas, progress, video {
+    display: inline-block;
+    vertical-align: baseline;
+}
+
+    audio:not([controls]) {
+        display: none;
+        height: 0;
+    }
+
+[hidden], template {
+    display: none;
+}
+
+a {
+    background: transparent;
+}
+
+    a:active, a:hover {
+        outline: 0;
+    }
+
+abbr[title] {
+    border-bottom: 1px dotted;
+}
+
+b, strong {
+    font-weight: bold;
+}
+
+dfn {
+    font-style: italic;
+}
+
+h1 {
+    font-size: 2em;
+    margin: .67em 0;
+}
+
+mark {
+    background: #ff0;
+    color: #000;
+}
+
+small {
+    font-size: 80%;
+}
+
+sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+}
+
+sup {
+    top: -0.5em;
+}
+
+sub {
+    bottom: -0.25em;
+}
+
+img {
+    border: 0;
+}
+
+svg:not(:root) {
+    overflow: hidden;
+}
+
+figure {
+    margin: 1em 40px;
+}
+
+hr {
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    height: 0;
+}
+
+pre {
+    overflow: auto;
+}
+
+code, kbd, pre, samp {
+    font-family: monospace,monospace;
+    font-size: 1em;
+}
+
+button, input, optgroup, select, textarea {
+    color: inherit;
+    font: inherit;
+    margin: 0;
+}
+
+button {
+    overflow: visible;
+}
+
+button, select {
+    text-transform: none;
+}
+
+button, html input[type="button"], input[type="reset"], input[type="submit"] {
+    -webkit-appearance: button;
+    cursor: pointer;
+}
+
+    button[disabled], html input[disabled] {
+        cursor: default;
+    }
+
+    button::-moz-focus-inner, input::-moz-focus-inner {
+        border: 0;
+        padding: 0;
+    }
+
+input {
+    line-height: normal;
+}
+
+    input[type="checkbox"], input[type="radio"] {
+        box-sizing: border-box;
+        padding: 0;
+    }
+
+    input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button {
+        height: auto;
+    }
+
+    input[type="search"] {
+        -webkit-appearance: textfield;
+        -moz-box-sizing: content-box;
+        -webkit-box-sizing: content-box;
+        box-sizing: content-box;
+    }
+
+        input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration {
+            -webkit-appearance: none;
+        }
+
+fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: .35em .625em .75em;
+}
+
+legend {
+    border: 0;
+    padding: 0;
+}
+
+textarea {
+    overflow: auto;
+}
+
+optgroup {
+    font-weight: bold;
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+td, th {
+    padding: 0;
+}
 
 
 @font-face {
     font-family: "Menlo";
-   font-style: normal;
-  font-weight: 300;
-  src: url(../fonts/MenloPlus-Regular.ttf) format("truetype");
+    font-style: normal;
+    font-weight: 300;
+    src: url(../fonts/MenloPlus-Regular.ttf) format("truetype");
 }
 
 @font-face {
     font-family: "Menlo";
-   font-style: normal;
-  font-weight: 700;
-  src: url(../fonts/MenloPlus-Bold.ttf) format("truetype");
+    font-style: normal;
+    font-weight: 700;
+    src: url(../fonts/MenloPlus-Bold.ttf) format("truetype");
 }
 
 html {
@@ -36,15 +220,17 @@ ul {
     margin: 0;
     padding-left: 0;
 }
-a{
+
+a {
     color: #333;
     text-decoration: none;
 }
+
 .wrap {
     position: relative;
 }
 
-.override,.override2 {
+.override, .override2 {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -82,9 +268,9 @@ a{
     padding-left: 0;
 }
 
-.control ul li {
-    display: inline-block;
-}
+    .control ul li {
+        display: inline-block;
+    }
 
 .control a {
     display: inline-block;
@@ -92,7 +278,7 @@ a{
     padding: 0 5px;
 }
 
-.control .dropdown,.control .topDropdown {
+.control .dropdown, .control .topDropdown {
     position: absolute;
     top: 64px;
     left: 0px;
@@ -106,20 +292,20 @@ a{
     display: inline-block;
 }
 
-.dropdown li span {
-    cursor: pointer;
-    padding: 0 5px;
-    height: 35px;
-    line-height: 35px;
-    display: inline-block;
-    color: #999;
-}
+    .dropdown li span {
+        cursor: pointer;
+        padding: 0 5px;
+        height: 35px;
+        line-height: 35px;
+        display: inline-block;
+        color: #999;
+    }
 
-.dropdown li span:hover {
-    background: linear-gradient(to bottom, rgba(225, 225, 228, 0.31), rgba(242, 242, 245, 0.11));
-    border-color: rgba(0,0,0,0.15);
-    box-shadow: inset 0 1px rgba(0,0,0,0.07),inset 0 1px 2px rgba(0,0,0,0.1),1px 0 rgba(255,255,255,0.2),-1px 0 rgba(255,255,255,0.2);
-}
+        .dropdown li span:hover {
+            background: linear-gradient(to bottom, rgba(225, 225, 228, 0.31), rgba(242, 242, 245, 0.11));
+            border-color: rgba(0,0,0,0.15);
+            box-shadow: inset 0 1px rgba(0,0,0,0.07),inset 0 1px 2px rgba(0,0,0,0.1),1px 0 rgba(255,255,255,0.2),-1px 0 rgba(255,255,255,0.2);
+        }
 
 .control span {
     display: block;
@@ -127,9 +313,9 @@ a{
     cursor: pointer;
 }
 
-.control span:hover {
-    background-color: #eee;
-}
+    .control span:hover {
+        background-color: #eee;
+    }
 
 .control .tool-dropdown span {
     width: 100px;
@@ -147,28 +333,28 @@ a{
     margin-right: 10px;
 }
 
-#file-action,.topAction {
+#file-action, .topAction {
     position: relative;
 }
 
-.file-action-active #file-action-href,.file-action-active .topActionHref {
+.file-action-active #file-action-href, .file-action-active .topActionHref {
     background: linear-gradient(to bottom, #e1e1e4, #f2f2f5);
     border-color: rgba(0,0,0,0.15);
     box-shadow: inset 0 1px rgba(0,0,0,0.07),inset 0 1px 2px rgba(0,0,0,0.1),1px 0 rgba(255,255,255,0.2),-1px 0 rgba(255,255,255,0.2);
 }
 
-#file-action-href,.topActionHref {
+#file-action-href, .topActionHref {
     border-top: none;
-    border-bottom: none
+    border-bottom: none;
 }
 
-#file-action-href b,.topActionHref b {
-    font-weight: 300;
-}
+    #file-action-href b, .topActionHref b {
+        font-weight: 300;
+    }
 
-#file-action-href:hover,#about-trigger:hover,.topActionHref:hover {
-    background-color: rgba(255, 255, 255, 0.68);
-}
+    #file-action-href:hover, #about-trigger:hover, .topActionHref:hover {
+        background-color: rgba(255, 255, 255, 0.68);
+    }
 
 .header {
     -webkit-app-region: drag;
@@ -208,9 +394,9 @@ a{
     color: #778087;
 }
 
-.header a:hover {
-    color: #333;
-}
+    .header a:hover {
+        color: #333;
+    }
 
 .header span {
     text-shadow: 0px 1px #fff;
@@ -244,23 +430,23 @@ ul.dropdown {
     height: 44px;
 }
 
-.opts span {
-    color: #333;
-    display: inline-block;
-}
+    .opts span {
+        color: #333;
+        display: inline-block;
+    }
 
-.opts .expand {
-    color: #6e6e6e;
-    font-size: 22px;
-    font-weight: 700;
-    display: inline-block;
-    line-height: 44px;
-    height: 44px;
-}
+    .opts .expand {
+        color: #6e6e6e;
+        font-size: 22px;
+        font-weight: 700;
+        display: inline-block;
+        line-height: 44px;
+        height: 44px;
+    }
 
-.opts .expand:hover {
-    color: #333;
-}
+        .opts .expand:hover {
+            color: #333;
+        }
 
 .features {
     padding-top: 0px;
@@ -325,7 +511,7 @@ a.osx-window-btn.green {
 
 .current-file {
     cursor: pointer;
-     -webkit-app-region: no-drag;
+    -webkit-app-region: no-drag;
     text-align: center;
     text-shadow: 0 1px #fff;
     font-size: 16px;
@@ -355,28 +541,31 @@ a.osx-window-btn.green {
 ::-webkit-scrollbar {
     width: 10px;
 }
- 
+
 /* Track */
 ::-webkit-scrollbar-track {
     background-color: white;
 }
- 
+
 /* Handle */
 ::-webkit-scrollbar-thumb {
     min-height: 1rem;
     background: #ccc;
     background-clip: padding-box;
     border: 3px solid white;
-    border-radius: 5px
+    border-radius: 5px;
 }
-::-webkit-scrollbar-thumb:active {
-    background-color: #999;
-    border-width: 2px
-}
-::-webkit-scrollbar-thumb:window-inactive {
-    background: #eee; 
-}
-hr{
+
+    ::-webkit-scrollbar-thumb:active {
+        background-color: #999;
+        border-width: 2px;
+    }
+
+    ::-webkit-scrollbar-thumb:window-inactive {
+        background: #eee;
+    }
+
+hr {
     border: none;
     height: 1px;
     background-color: #eee;
@@ -384,13 +573,14 @@ hr{
     margin: 0 auto;
 }
 
-.sketch{
+.sketch {
     position: fixed;
     width: 100%;
     height: 100%;
     z-index: -1;
 }
-.settings{
+
+.settings {
     position: fixed;
     top: 0;
     left: -260px;
@@ -406,15 +596,16 @@ hr{
     /*background-image: url(http://s2.music.126.net/style/web2/img/playlist_bg.png?ed5cf7aaf67380ad1d6cd7ba7f69e51f);
     dark mode */
 }
-.settings-body{
+
+.settings-body {
     position: absolute;
     top: 44px;
     left: 0;
     height: 100%;
     width: 100%;
-
 }
-.settings-top{
+
+.settings-top {
     position: absolute;
     top: 0;
     left: 0;
@@ -426,7 +617,7 @@ hr{
     overflow: hidden;
 }
 
-#settings-trigger{
+#settings-trigger {
     position: absolute;
     left: 3px;
     top: 0px;
@@ -438,56 +629,64 @@ hr{
     color: #6e6e6e;
     -webkit-app-region: no-drag;
 }
-.settings-tabs{
+
+.settings-tabs {
     margin: 0;
     padding-left: 0;
     height: 44px;
     line-height: 44px;
     position: relative;
 }
-.settings-tab{
+
+.settings-tab {
     display: inline-block;
     width: 49%;
     float: left;
     text-align: center;
 }
-.settings-tab a{
-    color: #333;
-    text-decoration: none;
-    display: inline-block;
-    line-height: 20px;
-    height: 20px;
-    padding: 3px 20px;
-    position: relative;
-    text-shadow: 0 1px #fff;
-    transition: all .15s ease-in-out;
-}
-.settings-tab a:hover{
-}
-.settings-tab a:after{
-    content: "";
-    position: absolute;
-    background: rgba(171, 171, 171, 0.15);
-    width: 100px;
-    height: 5px;
-    left: 50%;
-    margin-left: -50px;
-    top: 50%;
-    margin-top: 32.5px;
-    border-radius: 4px;
-    transition: all .35s ease-in-out;
-}
-.settings-tab a:hover:after,.settings-tab a.tabbed:after{
-    content:"";
-    height: 25px;
-    margin-top: -12.5px;
-}
-.settings-tab span {
-    font-size: 16px;
-    position: relative;
-    top: 2px;
-}
-.settings-sep{
+
+    .settings-tab a {
+        color: #333;
+        text-decoration: none;
+        display: inline-block;
+        line-height: 20px;
+        height: 20px;
+        padding: 3px 20px;
+        position: relative;
+        text-shadow: 0 1px #fff;
+        transition: all .15s ease-in-out;
+    }
+
+        .settings-tab a:hover {
+        }
+
+        .settings-tab a:after {
+            content: "";
+            position: absolute;
+            background: rgba(171, 171, 171, 0.15);
+            width: 100px;
+            height: 5px;
+            left: 50%;
+            margin-left: -50px;
+            top: 50%;
+            margin-top: 32.5px;
+            border-radius: 4px;
+            transition: all .35s ease-in-out;
+        }
+
+        .settings-tab a:hover:after, .settings-tab a.tabbed:after {
+            content: "";
+            height: 25px;
+            margin-top: -12.5px;
+        }
+
+    .settings-tab span {
+        font-size: 16px;
+        position: relative;
+        top: 2px;
+    }
+
+.settings-sep {
     width: 1px;
     height: 16px;
     line-height: 10px;
@@ -498,12 +697,14 @@ hr{
     margin-left: .5px;
     background: rgba(204, 204, 204, 0.19);
 }
-.settings-title{
+
+.settings-title {
     color: rgba(238, 238, 238, 0.85);
     font-size: 14px;
     font-weight: normal;
     padding-left: 20px;
 }
+
 .ios7-switch.line-sample {
     display: block;
     font-size: 14px;
@@ -519,8 +720,9 @@ hr{
     -ms-user-select: none;
     user-select: none;
     color: #333;
-    text-shadow :0 1px #fff;
+    text-shadow: 0 1px #fff;
 }
+
 .ios7-switch {
     display: inline-block;
     position: relative;
@@ -533,104 +735,101 @@ hr{
     tap-highlight-color: transparent;
 }
 
-.ios7-switch input[type=checkbox] {
-    opacity: 0;
-    position: absolute;
-}
+    .ios7-switch input[type=checkbox] {
+        opacity: 0;
+        position: absolute;
+    }
 
-.ios7-switch input + span {
-    position: relative;
-    display: inline-block;
-    width: 1.65em;
-    height: 1em;
-    background: white;
-    box-shadow: inset 0 0 0 0.0625em #e9e9e9;
-    border-radius: 0.5em;
-    vertical-align: -0.15em;
-    transition: all 0.40s cubic-bezier(.17,.67,.43,.98);
-    float: right;
-    font-size: 1.5em;
-}
+    .ios7-switch input + span {
+        position: relative;
+        display: inline-block;
+        width: 1.65em;
+        height: 1em;
+        background: white;
+        box-shadow: inset 0 0 0 0.0625em #e9e9e9;
+        border-radius: 0.5em;
+        vertical-align: -0.15em;
+        transition: all 0.40s cubic-bezier(.17,.67,.43,.98);
+        float: right;
+        font-size: 1.5em;
+    }
 
-.ios7-switch:active input + span,
-.ios7-switch input + span:active {
-    box-shadow: inset 0 0 0 0.73em #e9e9e9;
-}
+        .ios7-switch:active input + span,
+        .ios7-switch input + span:active {
+            box-shadow: inset 0 0 0 0.73em #e9e9e9;
+        }
 
-.ios7-switch input + span:after {
-    position: absolute;
-    display: block;
-    content: '';
-    width: 0.875em;
-    height: 0.875em;
-    border-radius: 0.4375em;
-    top: 0.0625em;
-    left: 0.0625em;
-    background: white;
-    box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.1),
-                0 0 0.05em rgba(0,0,0,0.05),
-                0 0.1em 0.2em rgba(0,0,0,0.2);
-    transition: all 0.25s ease-out;
-}
+        .ios7-switch input + span:after {
+            position: absolute;
+            display: block;
+            content: '';
+            width: 0.875em;
+            height: 0.875em;
+            border-radius: 0.4375em;
+            top: 0.0625em;
+            left: 0.0625em;
+            background: white;
+            box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.1), 0 0 0.05em rgba(0,0,0,0.05), 0 0.1em 0.2em rgba(0,0,0,0.2);
+            transition: all 0.25s ease-out;
+        }
 
-.ios7-switch:active input + span:after,
-.ios7-switch input + span:active:after {
-    width: 1.15em;
-}
+        .ios7-switch:active input + span:after,
+        .ios7-switch input + span:active:after {
+            width: 1.15em;
+        }
 
-.ios7-switch input:checked + span {
-    box-shadow: inset 0 0 0 0.73em #4cd964;
-}
+    .ios7-switch input:checked + span {
+        box-shadow: inset 0 0 0 0.73em #4cd964;
+    }
 
-.ios7-switch input:checked + span:after {
-    left: 0.7125em;
-}
+        .ios7-switch input:checked + span:after {
+            left: 0.7125em;
+        }
 
-.ios7-switch:active input:checked + span:after,
-.ios7-switch input:checked + span:active:after {
-    left: 0.4375em;
-}
+        .ios7-switch:active input:checked + span:after,
+        .ios7-switch input:checked + span:active:after {
+            left: 0.4375em;
+        }
 
-/* accessibility styles */
-.ios7-switch input:focus + span:after {
-    box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.15),
-                0 0 0.05em rgba(0,0,0,0.08),
-                0 0.1em 0.2em rgba(0,0,0,0.3);
-    background: #fff;
-}
+    /* accessibility styles */
+    .ios7-switch input:focus + span:after {
+        box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.15), 0 0 0.05em rgba(0,0,0,0.08), 0 0.1em 0.2em rgba(0,0,0,0.3);
+        background: #fff;
+    }
 
-.ios7-switch input:focus + span {
-    box-shadow: inset 0 0 0 0.0625em #dadada;
-}
+    .ios7-switch input:focus + span {
+        box-shadow: inset 0 0 0 0.0625em #dadada;
+    }
 
-.ios7-switch input:focus:checked + span {
-    box-shadow: inset 0 0 0 0.73em #33be4b;
-}
+    .ios7-switch input:focus:checked + span {
+        box-shadow: inset 0 0 0 0.73em #33be4b;
+    }
 
-/* reset accessibility style on hover */
-.ios7-switch:hover input:focus + span:after {
-    box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.1),
-                0 0 0.05em rgba(0,0,0,0.05),
-                0 0.1em 0.2em rgba(0,0,0,0.2);
-    background: #fff;
-}
+    /* reset accessibility style on hover */
+    .ios7-switch:hover input:focus + span:after {
+        box-shadow: inset 0 0 0 0.03em rgba(0,0,0,0.1), 0 0 0.05em rgba(0,0,0,0.05), 0 0.1em 0.2em rgba(0,0,0,0.2);
+        background: #fff;
+    }
 
-.ios7-switch:hover input:focus + span {
-    box-shadow: inset 0 0 0 0.0625em #e9e9e9;
-}
+    .ios7-switch:hover input:focus + span {
+        box-shadow: inset 0 0 0 0.0625em #e9e9e9;
+    }
 
-.ios7-switch:hover input:focus:checked + span {
-    box-shadow: inset 0 0 0 0.73em #4cd964;
-}
-.line-sample i{
+    .ios7-switch:hover input:focus:checked + span {
+        box-shadow: inset 0 0 0 0.73em #4cd964;
+    }
+
+.line-sample i {
     font-size: 1.5em;
     color: #999;
     transition: all .15s ease-in-out;
 }
-.gone{
+
+.gone {
     display: none;
 }
-.sub-setting{
+
+.sub-setting {
     color: #778087;
     border: solid rgba(221, 221, 221, 0.42);
     border-width: 1px 0 0 0;
@@ -639,21 +838,21 @@ hr{
     font-size: 13px;
     background: rgba(255, 255, 255, 0.59);
 }
-.left2right{
+
+.left2right {
 }
-#css-input-trigger{
+
+#css-input-trigger {
     cursor: pointer;
 }
-#css-input-trigger:hover{
-    background-color: #f9f9f9;
-}
+
+    #css-input-trigger:hover {
+        background-color: #f9f9f9;
+    }
+
 .notie {
     background-color: #c4453c;
-    background-image: -webkit-linear-gradient(135deg, transparent,
-                      transparent 25%, hsla(0,0%,0%,.05) 25%,
-                      hsla(0,0%,0%,.05) 50%, transparent 50%,
-                      transparent 75%, hsla(0,0%,0%,.05) 75%,
-                      hsla(0,0%,0%,.05));
+    background-image: -webkit-linear-gradient(135deg, transparent, transparent 25%, hsla(0,0%,0%,.05) 25%, hsla(0,0%,0%,.05) 50%, transparent 50%, transparent 75%, hsla(0,0%,0%,.05) 75%, hsla(0,0%,0%,.05));
     background-size: 20px 20px;
     box-shadow: 0 5px 0 hsla(0,0%,0%,.1);
     color: #f6f6f6;
@@ -664,7 +863,8 @@ hr{
     text-decoration: none;
     -webkit-animation: alert 1s ease forwards;
 }
-#github{
+
+#github {
     font-size: 24px;
     color: #333;
     text-decoration: none;
@@ -673,491 +873,504 @@ hr{
 /* Animation */
 
 @-webkit-keyframes alert {
-    0% { opacity: 0; }
-    50% { opacity: 1; }
-    100% { top: 0; }
+    0% {
+        opacity: 0;
+    }
+
+    50% {
+        opacity: 1;
+    }
+
+    100% {
+        top: 0;
+    }
 }
 
 /*******************/
 
 @-webkit-keyframes wobblebar {
-  0% {
-    left: 4px;
-  }
+    0% {
+        left: 4px;
+    }
 
-  3% {
-    left: 104px;
-  }
+    3% {
+        left: 104px;
+    }
 
-  6% {
-    left: 4px;
-  }
+    6% {
+        left: 4px;
+    }
 
-  9% {
-    left: 104px;
-  }
+    9% {
+        left: 104px;
+    }
 
-  12% {
-    left: 4px;
-  }
+    12% {
+        left: 4px;
+    }
 
-  15% {
-    left: 104px;
-  }
+    15% {
+        left: 104px;
+    }
 
-  18% {
-    left: 32px;
-  }
+    18% {
+        left: 32px;
+    }
 
-  27% {
-    left: 32px;
-  }
+    27% {
+        left: 32px;
+    }
 
-  30% {
-    left: 104px;
-  }
+    30% {
+        left: 104px;
+    }
 
-  33% {
-    left: 4px;
-  }
+    33% {
+        left: 4px;
+    }
 
-  36% {
-    left: 104px;
-  }
+    36% {
+        left: 104px;
+    }
 
-  39% {
-    left: 4px;
-  }
+    39% {
+        left: 4px;
+    }
 
-  42% {
-    left: 104px;
-  }
+    42% {
+        left: 104px;
+    }
 
-  45% {
-    left: 4px;
-  }
+    45% {
+        left: 4px;
+    }
 
-  48% {
-    left: 104px;
-  }
+    48% {
+        left: 104px;
+    }
 
-  51% {
-    left: 52px;
-  }
+    51% {
+        left: 52px;
+    }
 
-  63% {
-    left: 52px;
-  }
+    63% {
+        left: 52px;
+    }
 
-  66% {
-    left: 4px;
-  }
+    66% {
+        left: 4px;
+    }
 
-  69% {
-    left: 104px;
-  }
+    69% {
+        left: 104px;
+    }
 
-  72% {
-    left: 4px;
-  }
+    72% {
+        left: 4px;
+    }
 
-  75% {
-    left: 104px;
-  }
+    75% {
+        left: 104px;
+    }
 
-  78% {
-    left: 4px;
-  }
+    78% {
+        left: 4px;
+    }
 
-  81% {
-    left: 104px;
-  }
+    81% {
+        left: 104px;
+    }
 
-  84% {
-    left: 72px;
-  }
+    84% {
+        left: 72px;
+    }
 
-  94% {
-    left: 72px;
-  }
+    94% {
+        left: 72px;
+    }
 
-  97% {
-    left: 104px;
-  }
+    97% {
+        left: 104px;
+    }
 }
 
 @-moz-keyframes wobblebar {
-  0% {
-    left: 4px;
-  }
+    0% {
+        left: 4px;
+    }
 
-  3% {
-    left: 104px;
-  }
+    3% {
+        left: 104px;
+    }
 
-  6% {
-    left: 4px;
-  }
+    6% {
+        left: 4px;
+    }
 
-  9% {
-    left: 104px;
-  }
+    9% {
+        left: 104px;
+    }
 
-  12% {
-    left: 4px;
-  }
+    12% {
+        left: 4px;
+    }
 
-  15% {
-    left: 104px;
-  }
+    15% {
+        left: 104px;
+    }
 
-  18% {
-    left: 32px;
-  }
+    18% {
+        left: 32px;
+    }
 
-  27% {
-    left: 32px;
-  }
+    27% {
+        left: 32px;
+    }
 
-  30% {
-    left: 104px;
-  }
+    30% {
+        left: 104px;
+    }
 
-  33% {
-    left: 4px;
-  }
+    33% {
+        left: 4px;
+    }
 
-  36% {
-    left: 104px;
-  }
+    36% {
+        left: 104px;
+    }
 
-  39% {
-    left: 4px;
-  }
+    39% {
+        left: 4px;
+    }
 
-  42% {
-    left: 104px;
-  }
+    42% {
+        left: 104px;
+    }
 
-  45% {
-    left: 4px;
-  }
+    45% {
+        left: 4px;
+    }
 
-  48% {
-    left: 104px;
-  }
+    48% {
+        left: 104px;
+    }
 
-  51% {
-    left: 52px;
-  }
+    51% {
+        left: 52px;
+    }
 
-  63% {
-    left: 52px;
-  }
+    63% {
+        left: 52px;
+    }
 
-  66% {
-    left: 4px;
-  }
+    66% {
+        left: 4px;
+    }
 
-  69% {
-    left: 104px;
-  }
+    69% {
+        left: 104px;
+    }
 
-  72% {
-    left: 4px;
-  }
+    72% {
+        left: 4px;
+    }
 
-  75% {
-    left: 104px;
-  }
+    75% {
+        left: 104px;
+    }
 
-  78% {
-    left: 4px;
-  }
+    78% {
+        left: 4px;
+    }
 
-  81% {
-    left: 104px;
-  }
+    81% {
+        left: 104px;
+    }
 
-  84% {
-    left: 72px;
-  }
+    84% {
+        left: 72px;
+    }
 
-  94% {
-    left: 72px;
-  }
+    94% {
+        left: 72px;
+    }
 
-  97% {
-    left: 104px;
-  }
+    97% {
+        left: 104px;
+    }
 }
 
 @-o-keyframes wobblebar {
-  0% {
-    left: 4px;
-  }
+    0% {
+        left: 4px;
+    }
 
-  3% {
-    left: 104px;
-  }
+    3% {
+        left: 104px;
+    }
 
-  6% {
-    left: 4px;
-  }
+    6% {
+        left: 4px;
+    }
 
-  9% {
-    left: 104px;
-  }
+    9% {
+        left: 104px;
+    }
 
-  12% {
-    left: 4px;
-  }
+    12% {
+        left: 4px;
+    }
 
-  15% {
-    left: 104px;
-  }
+    15% {
+        left: 104px;
+    }
 
-  18% {
-    left: 32px;
-  }
+    18% {
+        left: 32px;
+    }
 
-  27% {
-    left: 32px;
-  }
+    27% {
+        left: 32px;
+    }
 
-  30% {
-    left: 104px;
-  }
+    30% {
+        left: 104px;
+    }
 
-  33% {
-    left: 4px;
-  }
+    33% {
+        left: 4px;
+    }
 
-  36% {
-    left: 104px;
-  }
+    36% {
+        left: 104px;
+    }
 
-  39% {
-    left: 4px;
-  }
+    39% {
+        left: 4px;
+    }
 
-  42% {
-    left: 104px;
-  }
+    42% {
+        left: 104px;
+    }
 
-  45% {
-    left: 4px;
-  }
+    45% {
+        left: 4px;
+    }
 
-  48% {
-    left: 104px;
-  }
+    48% {
+        left: 104px;
+    }
 
-  51% {
-    left: 52px;
-  }
+    51% {
+        left: 52px;
+    }
 
-  63% {
-    left: 52px;
-  }
+    63% {
+        left: 52px;
+    }
 
-  66% {
-    left: 4px;
-  }
+    66% {
+        left: 4px;
+    }
 
-  69% {
-    left: 104px;
-  }
+    69% {
+        left: 104px;
+    }
 
-  72% {
-    left: 4px;
-  }
+    72% {
+        left: 4px;
+    }
 
-  75% {
-    left: 104px;
-  }
+    75% {
+        left: 104px;
+    }
 
-  78% {
-    left: 4px;
-  }
+    78% {
+        left: 4px;
+    }
 
-  81% {
-    left: 104px;
-  }
+    81% {
+        left: 104px;
+    }
 
-  84% {
-    left: 72px;
-  }
+    84% {
+        left: 72px;
+    }
 
-  94% {
-    left: 72px;
-  }
+    94% {
+        left: 72px;
+    }
 
-  97% {
-    left: 104px;
-  }
+    97% {
+        left: 104px;
+    }
 }
 
 @keyframes wobblebar {
-  0% {
-    left: 4px;
-  }
+    0% {
+        left: 4px;
+    }
 
-  3% {
-    left: 104px;
-  }
+    3% {
+        left: 104px;
+    }
 
-  6% {
-    left: 4px;
-  }
+    6% {
+        left: 4px;
+    }
 
-  9% {
-    left: 104px;
-  }
+    9% {
+        left: 104px;
+    }
 
-  12% {
-    left: 4px;
-  }
+    12% {
+        left: 4px;
+    }
 
-  15% {
-    left: 104px;
-  }
+    15% {
+        left: 104px;
+    }
 
-  18% {
-    left: 32px;
-  }
+    18% {
+        left: 32px;
+    }
 
-  27% {
-    left: 32px;
-  }
+    27% {
+        left: 32px;
+    }
 
-  30% {
-    left: 104px;
-  }
+    30% {
+        left: 104px;
+    }
 
-  33% {
-    left: 4px;
-  }
+    33% {
+        left: 4px;
+    }
 
-  36% {
-    left: 104px;
-  }
+    36% {
+        left: 104px;
+    }
 
-  39% {
-    left: 4px;
-  }
+    39% {
+        left: 4px;
+    }
 
-  42% {
-    left: 104px;
-  }
+    42% {
+        left: 104px;
+    }
 
-  45% {
-    left: 4px;
-  }
+    45% {
+        left: 4px;
+    }
 
-  48% {
-    left: 104px;
-  }
+    48% {
+        left: 104px;
+    }
 
-  51% {
-    left: 52px;
-  }
+    51% {
+        left: 52px;
+    }
 
-  63% {
-    left: 52px;
-  }
+    63% {
+        left: 52px;
+    }
 
-  66% {
-    left: 4px;
-  }
+    66% {
+        left: 4px;
+    }
 
-  69% {
-    left: 104px;
-  }
+    69% {
+        left: 104px;
+    }
 
-  72% {
-    left: 4px;
-  }
+    72% {
+        left: 4px;
+    }
 
-  75% {
-    left: 104px;
-  }
+    75% {
+        left: 104px;
+    }
 
-  78% {
-    left: 4px;
-  }
+    78% {
+        left: 4px;
+    }
 
-  81% {
-    left: 104px;
-  }
+    81% {
+        left: 104px;
+    }
 
-  84% {
-    left: 72px;
-  }
+    84% {
+        left: 72px;
+    }
 
-  94% {
-    left: 72px;
-  }
+    94% {
+        left: 72px;
+    }
 
-  97% {
-    left: 104px;
-  }
+    97% {
+        left: 104px;
+    }
 }
 
 /* Styles for old versions of IE */
 .wobblebar {
-  font-family: sans-serif;
-  font-weight: 100;
-  margin-top: 2.5px;
+    font-family: sans-serif;
+    font-weight: 100;
+    margin-top: 2.5px;
 }
 
-/* :not(:required) hides this rule from IE9 and below */
-.wobblebar:not(:required) {
-  background: #aa99dd;
-  -webkit-border-radius: 10.66667px;
-  -moz-border-radius: 10.66667px;
-  -ms-border-radius: 10.66667px;
-  -o-border-radius: 10.66667px;
-  border-radius: 10.66667px;
-  display: inline-block;
-  overflow: hidden;
-  text-indent: -9999px;
-  width: 128px;
-  height: 21.33333px;
-  position: relative;
-}
-.wobblebar:not(:required)::after {
-  -webkit-animation: wobblebar 15000ms infinite ease;
-  -moz-animation: wobblebar 15000ms infinite ease;
-  -ms-animation: wobblebar 15000ms infinite ease;
-  -o-animation: wobblebar 15000ms infinite ease;
-  animation: wobblebar 15000ms infinite ease;
-  background: white;
-  display: block;
-  -webkit-border-radius: 7.11111px;
-  -moz-border-radius: 7.11111px;
-  -ms-border-radius: 7.11111px;
-  -o-border-radius: 7.11111px;
-  border-radius: 7.11111px;
-  content: '';
-  position: absolute;
-  top: 3.55556px;
-  left: 4px;
-  width: 21.33333px;
-  height: 14.22222px;
-}
-#githubSetting{
+    /* :not(:required) hides this rule from IE9 and below */
+    .wobblebar:not(:required) {
+        background: #aa99dd;
+        -webkit-border-radius: 10.66667px;
+        -moz-border-radius: 10.66667px;
+        -ms-border-radius: 10.66667px;
+        -o-border-radius: 10.66667px;
+        border-radius: 10.66667px;
+        display: inline-block;
+        overflow: hidden;
+        text-indent: -9999px;
+        width: 128px;
+        height: 21.33333px;
+        position: relative;
+    }
+
+        .wobblebar:not(:required)::after {
+            -webkit-animation: wobblebar 15000ms infinite ease;
+            -moz-animation: wobblebar 15000ms infinite ease;
+            -ms-animation: wobblebar 15000ms infinite ease;
+            -o-animation: wobblebar 15000ms infinite ease;
+            animation: wobblebar 15000ms infinite ease;
+            background: white;
+            display: block;
+            -webkit-border-radius: 7.11111px;
+            -moz-border-radius: 7.11111px;
+            -ms-border-radius: 7.11111px;
+            -o-border-radius: 7.11111px;
+            border-radius: 7.11111px;
+            content: '';
+            position: absolute;
+            top: 3.55556px;
+            left: 4px;
+            width: 21.33333px;
+            height: 14.22222px;
+        }
+
+#githubSetting {
     display: none;
 }
-#gist-title{
+
+#gist-title {
     padding: 5px;
     border-color: 1px solid #eee;
     border-radius: 2px;
     cursor: text;
 }
-#auth_url{
+
+#auth_url {
     color: #333;
 }
+
 a.country {
     font-size: 12px;
     text-align: center;
@@ -1170,10 +1383,12 @@ a.country {
     transition: all .15s ease-in-out;
     border-bottom: 4px solid transparent;
 }
-a.country:hover {
-    background-color: rgba(0, 0, 0, 0.06);
-    line-height: 36px;
-}
-.hint--rounded:after{
+
+    a.country:hover {
+        background-color: rgba(0, 0, 0, 0.06);
+        line-height: 36px;
+    }
+
+.hint--rounded:after {
     text-shadow: none;
 }


### PR DESCRIPTION
1. reformat related code file, use uniform tabs or spaces in each single line .

2. make header and side-bar ui parts non-selectable
![qq 20150101184909](https://cloud.githubusercontent.com/assets/10270327/5592025/0a3c64c8-91e7-11e4-9713-6999c6b0b5bc.jpg)
![qq 20150101184922](https://cloud.githubusercontent.com/assets/10270327/5592026/0a3c8d7c-91e7-11e4-96c5-3c31dd7ec36a.jpg)

3. align editor and previewer initial height