### PR TITLE
current-file bar tweak

### DIFF
--- a/resource/css/ghostdown.css
+++ b/resource/css/ghostdown.css
@@ -369,24 +369,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
     }
 }
 
-
-@media (max-width: 860px), (max-width: 860px) {
-
-    .features .editor .outer {
-        padding: 0 40px;
-    }
-}
-
-@media (max-width: 800px), (max-width: 800px) {
-    .features .editor .outer {
-        padding: 0 30px;
-    }
-}
-
-@media (max-width: 400px), (max-width: 400px) {
-    .features .editor .outer {
-        padding: 0 15px;
-    }
+.outer, .editor, .features{
+    padding: 0;
 }
 
 .features .editor .editorwrap {

--- a/resource/css/main.css
+++ b/resource/css/main.css
@@ -515,29 +515,33 @@ a.osx-window-btn.green {
     margin-right: 20px;
 }
 
+.current-file, .current-file-input {
+    height: 26px;
+    overflow-x : hidden;
+    overflow-y : hidden;
+    border: 0;
+}
+
 .current-file {
-    cursor: pointer;
+    width: 300px;
     -webkit-app-region: no-drag;
     text-align: center;
     text-shadow: 0 1px #fff;
     font-size: 16px;
     margin: 0;
     font-size: 20px;
-    margin: 0;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 300px;
-    height: 26px;
+    top: 25%;
     line-height: 26px;
     margin-top: -13px;
-    margin-left: -150px;
+    margin-left: auto;
     background-color: #fff;
     border-radius: 3px;
     color: #999;
     display: inline-block;
     color: #52C983;
     font-weight: 300;
+    text-overflow : ellipsis;
+    white-space: nowrap;
 }
 
 #open_file {

--- a/resource/js/app.js
+++ b/resource/js/app.js
@@ -340,19 +340,55 @@ $(function() {
             }
         });
     });
-    $(".current-file").click(function() {
-        $(this).attr("contentEditable", true).css("cursor", "text").focus();
-    });
-    $(".current-file").on("blur", function() {
-        $(this).attr("contentEditable", false).css("cursor", "pointer");
-        //$('#savenew_file').val($(this).html())
-        $("#savenew_file").attr("nwsaveas", $(this).html()).attr("accept", "");
-        if ($(this).data("save") == true) {
-            //已存在的文件重命名
-            var new_location = path.dirname($(this).data("location")) + "/" + $(this).html();
-            $(this).data("location", new_location);
+    $(".current-file").click(function () {
+        var _ = this;
+        if (_.editing) {
+            return;
+        }
+        _.editing = true;
+        if ($(_).width() > 300) {
+            $(_).animate({ 'width': '300px' }, 200);
+        }
+        var txt = $(_).text();
+        $(_).empty();
+        var inline_editor = document.createElement("input");
+        inline_editor.setAttribute('type', 'text');
+        inline_editor.className = "current-file";
+        inline_editor.value = txt;
+        $(_).append(inline_editor);
+        $(inline_editor)
+            .focus()
+            .on('blur', function () {
+                var txt_now = inline_editor.value;
+                if (!txt_now) { txt_now = txt; }
+                $(inline_editor).remove();
+                $(_).text(txt_now);
+                _.editing = false;
+                $("#savenew_file").attr("nwsaveas", $(_).html()).attr("accept", "");
+                if ($(_).data("save") == true) {
+                    //已存在的文件重命名
+                    var new_location = path.dirname($(_).data("location")) + "/" + $(_).html();
+                    $(_).data("location", new_location);
+                }
+            });
+    }).on('mouseover', function (e) {
+        if (!this.editing) {
+            var elem = $(this).clone().css({ "height": "auto", "width": "auto" }).appendTo("body");
+            var width = elem.width();
+            elem.remove();
+            console && console.log("current title width: " + width);
+            if (width > 300) {
+                $(this).css('text-overflow', 'initial').animate({ width: width + "px" }, 200);
+            }
+        }
+    })
+    .on('mouseout', function (e) {
+        if (!this.editing) {
+            $(this).css('text-overflow', 'ellipsis').animate({ width: "300px" }, 200);
         }
     });
+
+    ;
     $("body").keydown(function(e) {
         if ((e.ctrlKey || e.metaKey) && e.which === 83 && !e.shiftKey) {
             if ($(".current-file").data("save") == true) {


### PR DESCRIPTION
1 on my pc ( windows 8.1 x64), those 'reactive padding' css rules makes the editor shorter than the header when window width is less than 860px, so I removed those rules. Should be ok on other envs but I didn't test.

2 use a "text input" to substitute the "contentEditable" implementation of "current-file" part.